### PR TITLE
Add Missing Chalk Dependency

### DIFF
--- a/bin/mockyeah-record.js
+++ b/bin/mockyeah-record.js
@@ -9,6 +9,7 @@
 
 const program = require('commander');
 const boot = require('../lib/boot');
+const chalk = require('chalk');
 let name;
 
 program


### PR DESCRIPTION
Record was failing due to missing import.
