### PR TITLE
Add Initialization Command

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -12,6 +12,7 @@ const version = require('../version');
 
 program
   .version(version)
+  .command('init', 'initialize mockyeah configuration')
   .command('ls', 'list captured service response recordings')
   .command('play [name]', 'playback captured service response recording')
   .command('record [name]', 'capture service response recording')

--- a/bin/mockyeah-init.js
+++ b/bin/mockyeah-init.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/* eslint-disable no-console, no-sync */
+
+/**
+ * `mockyeah init` initializes mockyeah configuration.
+ */
+
+const fs = require('fs');
+const program = require('commander');
+const inquirer = require('inquirer');
+const chalk = require('chalk');
+const print = require('pretty-print');
+
+program
+  .parse(process.argv);
+
+const currentDirectory = process.cwd();
+const initialize = () => {
+  inquirer.prompt([{
+    type: 'input',
+    name: 'name',
+    message: 'Choose a name for the mockyeah server:'
+  }, {
+    type: 'input',
+    name: 'host',
+    message: 'Choose a host for mockyeah to run on:'
+  }, {
+    type: 'input',
+    name: 'port',
+    message: 'Choose a port for mockyeah to run on:'
+  }, {
+    type: 'input',
+    name: 'fixturesDir',
+    message: 'Choose a directory for mockyeah to locate fixtures:'
+  }], answers => {
+    const data = {
+      name: answers.name || 'mockyeah',
+      host: answers.host || 'localhost',
+      port: parseInt(answers.port, 10) || 4001,
+      fixturesDir: answers.fixturesDir || './mockyeah/fixtures'
+    };
+
+    fs.writeFile('.mockyeah', JSON.stringify(data), err => {
+      if (err) console.log(chalk.red(err));
+
+      console.log(`.mockyeah written at ${currentDirectory}`);
+      print(data);
+    });
+  });
+};
+
+try {
+  fs.accessSync(currentDirectory + '/.mockyeah', fs.F_OK);
+  inquirer.prompt([{
+    type: 'confirm',
+    name: 'overwrite',
+    message: '.mockyeah file already exists; Overwrite?'
+  }], answer => {
+    if (answer.overwrite) initialize();
+  });
+} catch (err) {
+  initialize();
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "commander": "^2.9.0",
     "inquirer": "^0.11.4",
     "liftoff": "^2.2.0",
+    "pretty-print": "^1.1.0",
     "tildify": "^1.1.2",
     "v8flags": "^2.0.11"
   },


### PR DESCRIPTION
It would be helpful to have an initialization command. Most CLI's come with some sort of `init` baked in, this implementation will add a `.mockyeah` file in the current working directory, and will ask if you'd like to overwrite an existing `.mockyeah` file if one already exists.
